### PR TITLE
Add basic nix support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754974548,
+        "narHash": "sha256-XMjUjKD/QRPcqUnmSDczSYdw46SilnG0+wkho654DFM=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "27a26be51ff0162a8f67660239f9407dba68d7c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "A hackable cli/tui launcher built for keyboard-centric wm users";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default-linux";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    let
+      args = {
+        inherit inputs;
+      };
+
+      module = {
+        systems = import inputs.systems;
+
+        imports = [
+          inputs.home-manager.flakeModules.default
+          ./nix
+        ];
+      };
+    in
+    inputs.flake-parts.lib.mkFlake args module;
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./package.nix
+    ./modules
+  ];
+}

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./home-manager.nix
+    ./nixos.nix
+  ];
+}

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -1,0 +1,46 @@
+{ moduleWithSystem, ... }:
+let
+  otter-launcher-module =
+    { self', ... }:
+    { config, pkgs, lib, ... }:
+    let
+      otter-launcher = self'.packages.default;
+
+      toml-format = pkgs.formats.toml { };
+      toml = toml-format.type;
+
+      cfg = config.programs.otter-launcher;
+    in
+    {
+      options.programs.otter-launcher = {
+        enable = lib.mkEnableOption "otter-launcher";
+
+        settings = lib.mkOption {
+          type = toml;
+          default = { };
+          defaultText = lib.literalExpression "{ }";
+          description = ''
+            Configuration written to {file}`$XDG_CONFIG_DIR/otter-launcher/config.toml`.
+
+            See <https://github.com/kuokuo123/otter-launcher/blob/main/README.md#configuration>.
+          '';
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        home.packages = [ otter-launcher ];
+
+        xdg.configFile."otter-launcher/config.toml" = lib.mkIf (cfg.settings != { }) {
+          source = toml-format.generate "otter-launcher-config" cfg.settings;
+        };
+      };
+    };
+
+  otter-launcher = moduleWithSystem otter-launcher-module;
+in
+{
+  flake.homeModules = {
+    inherit otter-launcher;
+    default = otter-launcher;
+  };
+}

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,0 +1,46 @@
+{ moduleWithSystem, ... }:
+let
+  otter-launcher-module =
+    { self', ... }:
+    { config, pkgs, lib, ... }:
+    let
+      otter-launcher = self'.packages.default;
+
+      toml-format = pkgs.formats.toml { };
+      toml = toml-format.type;
+
+      cfg = config.programs.otter-launcher;
+    in
+    {
+      options.programs.otter-launcher = {
+        enable = lib.mkEnableOption "otter-launcher";
+
+        settings = lib.mkOption {
+          type = toml;
+          default = { };
+          defaultText = lib.literalExpression "{ }";
+          description = ''
+            Configuration written to {file}`/etc/otter-launcher/config.toml`.
+
+            See <https://github.com/kuokuo123/otter-launcher/blob/main/README.md#configuration>.
+          '';
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        home.packages = [ otter-launcher ];
+
+        environment.etc."otter-launcher/config.toml" = lib.mkIf (cfg.settings != { }) {
+          source = toml-format.generate "otter-launcher-config" cfg.settings;
+        };
+      };
+    };
+
+  otter-launcher = moduleWithSystem otter-launcher-module;
+in
+{
+  flake.nixosModules = {
+    inherit otter-launcher;
+    default = otter-launcher;
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,31 @@
+{ self, ... }:
+{
+  perSystem =
+    { pkgs, lib, ... }:
+    let
+      meta = {
+        mainProgram = "otter-launcher";
+        homepage = "https://github.com/kuokuo123/otter-launcher";
+        description = "A hackable cli/tui launcher built for keyboard-centric wm users";
+        license = lib.licenses.gpl3;
+        platforms = lib.platforms.linux;
+      };
+
+      otter-launcher = pkgs.rustPlatform.buildRustPackage {
+        inherit meta;
+        pname = "otter-launcher";
+        version = "git";
+
+        src = lib.sources.cleanSource self;
+
+        cargoLock.lockFile = "${self}/Cargo.lock";
+        cargoDepsName = "otter-launcher-deps";
+      };
+    in
+    {
+      packages = {
+        inherit otter-launcher;
+        default = otter-launcher;
+      };
+    };
+}


### PR DESCRIPTION
This PR adds basic nix support to the project. The changes include:
- Packaging `otter-launcher`
- Introducing `home-manager` module
- Introducing `NixOS` module
---
Fixes #6 