### PR TITLE
Optional Fuzzy matching for module prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "rustyline",
  "rustyline-derive",
  "serde",
+ "strsim",
  "toml",
  "urlencoding",
 ]
@@ -296,6 +297,12 @@ name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ regex = "1.11.1"
 rustyline = "17.0.2"
 rustyline-derive = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
+strsim = "0.11"
 toml = "0.9.2"
 urlencoding = "2.1.3"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ delay_startup = 0 # sometimes the otter runs too fast even before the terminal w
 #callback = "" # if set, will run after module execution; for example, calling swaymsg to adjust window size
 fuzzy_prefix = false # enable fuzzy prefix matching for typo tolerance
 fuzzy_min_length = 2 # minimum chars before fuzzy activates
-fuzzy_threshold = 0.7 # similarity threshold (0.0-1.0)
+fuzzy_threshold = 0.6 # similarity threshold (0.0-1.0)
 
 
 # ANSI color codes are allowed. However, \x1b should be replaced with \u001B, because the rust toml crate cannot read \x as an escaped character

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-
 <div align="center">
 
 ![fastfetch](./assets/logo2.png)
 
-*minimalist, blazingly fast, keyboard-centric*
+_minimalist, blazingly fast, keyboard-centric_
 
-  ![License](https://img.shields.io/badge/license-GPL_3.0-blue?style=flat-square)
-  ![written in Rust](https://img.shields.io/badge/language-rust-red.svg?style=flat-square)
+![License](https://img.shields.io/badge/license-GPL_3.0-blue?style=flat-square)
+![written in Rust](https://img.shields.io/badge/language-rust-red.svg?style=flat-square)
 
 </div>
 
@@ -73,7 +72,7 @@ Some helper scripts can be found in the [contrib](https://github.com/kuokuo123/o
 
 </div>
 
->External editor, list selection, and cheatsheet
+> External editor, list selection, and cheatsheet
 
 <div align="center">
 
@@ -127,7 +126,7 @@ The confing has four sections:
 
 All the available options are listed below. Check [more examples for module config](https://github.com/kuokuo123/otter-launcher/wiki) at the wiki page.
 
-``` toml
+```toml
 [general]
 default_module = "gg" # module to run when no prefix is matched
 empty_module = "app" # run with an empty prompt
@@ -142,6 +141,9 @@ loop_mode = false # don't quit after executing a module, useful with scratchpads
 external_editor = "vi" # if set, press ctrl+x ctrl+ee (or v in vi normal mode) to edit prompt in the specified program
 delay_startup = 0 # sometimes the otter runs too fast even before the terminal window is ready; this slows it down by milliseconds; useful when chafa image is skewed
 #callback = "" # if set, will run after module execution; for example, calling swaymsg to adjust window size
+fuzzy_prefix = false # enable fuzzy prefix matching for typo tolerance
+fuzzy_min_length = 2 # minimum chars before fuzzy activates
+fuzzy_threshold = 0.7 # similarity threshold (0.0-1.0)
 
 
 # ANSI color codes are allowed. However, \x1b should be replaced with \u001B, because the rust toml crate cannot read \x as an escaped character
@@ -309,7 +311,7 @@ Otter-launcher works well with tui, cli programs, and bash pipelines. Some trick
 
 2. [[modules]].cmd can be scripted to adjust window sizes. For example:
 
-``` toml
+```toml
 [[modules]]
 description = "pulsemixer for audio control"
 prefix = "vol"
@@ -320,13 +322,13 @@ cmd = "swaymsg [app_id=otter-launcher] resize set width 600 px height 300 px; pu
 
 4. Some tui utilities that works really well:
 
-    - Desktop app launcher: [sway-launcher-desktop](https://github.com/Biont/sway-launcher-desktop) [fsel](https://github.com/Mjoyufull/fsel)
-    - Audio control: [pulsemixer](https://github.com/GeorgeFilipkin/pulsemixer)
-    - Bluetooth control: [bluetui](https://github.com/pythops/bluetui) [bluetuith](https://github.com/darkhz/bluetuith)
-    - Wifi control: [nmtui](https://archlinux.org/packages/extra/x86_64/networkmanager/) [impala](https://github.com/pythops/impala)
-    - Spotify: [spotify_player](https://github.com/aome510/spotify-player)
-    - Mouse control: [wl-kbptr](https://github.com/moverest/wl-kbptr)
-    - More on [Awesome TUIs](https://github.com/rothgar/awesome-tuis) or [Awesome Command Line(CLI/TUI) Programs](https://github.com/toolleeo/awesome-cli-apps-in-a-csv).
+   - Desktop app launcher: [sway-launcher-desktop](https://github.com/Biont/sway-launcher-desktop) [fsel](https://github.com/Mjoyufull/fsel)
+   - Audio control: [pulsemixer](https://github.com/GeorgeFilipkin/pulsemixer)
+   - Bluetooth control: [bluetui](https://github.com/pythops/bluetui) [bluetuith](https://github.com/darkhz/bluetuith)
+   - Wifi control: [nmtui](https://archlinux.org/packages/extra/x86_64/networkmanager/) [impala](https://github.com/pythops/impala)
+   - Spotify: [spotify_player](https://github.com/aome510/spotify-player)
+   - Mouse control: [wl-kbptr](https://github.com/moverest/wl-kbptr)
+   - More on [Awesome TUIs](https://github.com/rothgar/awesome-tuis) or [Awesome Command Line(CLI/TUI) Programs](https://github.com/toolleeo/awesome-cli-apps-in-a-csv).
 
 5. It's recommended to setup a dedicated desktop app launcher as a module, like [fsel](https://github.com/Mjoyufull/fsel) (rust and very fast) or [sway-launcher-desktop](https://github.com/Biont/sway-launcher-desktop) (bash speed). The default config is just a simple script finding into regular directories and flatpak. If your apps are from different sources, it won't show.
 
@@ -336,7 +338,7 @@ cmd = "swaymsg [app_id=otter-launcher] resize set width 600 px height 300 px; pu
 
 ```
 binds {
-        Mod+Space { 
+        Mod+Space {
             spawn-sh "pkill otter-launcher || \
             kitten panel -1 \
                 --layer=overlay \
@@ -404,9 +406,9 @@ hint_color = "\u001B[90m"
 
 Since v0.6.4 fastfetch in interface.header_cmd is supported. It works without extra settings.
 
-However, fastfetch comes with its own "pipe mode" that sometimes does not pipe colors, so using it in overlay.overlay_cmd should turn an extra switch "fastfetch --pipe false". 
+However, fastfetch comes with its own "pipe mode" that sometimes does not pipe colors, so using it in overlay.overlay_cmd should turn an extra switch "fastfetch --pipe false".
 
-``` toml
+```toml
 [interface]
 header_cmd = """
 printf "\n"
@@ -438,7 +440,7 @@ Using chafa in header_cmd to render the image.
 
 </div>
 
-``` toml
+```toml
 [interface]
 header_cmd = "chafa --fit-width $HOME/.config/otter-launcher/images_other/waterways_and_otterways.jpg"
 header_cmd_trimmed_lines = 1

--- a/config_example/config.toml
+++ b/config_example/config.toml
@@ -34,6 +34,9 @@ loop_mode = false # don't quit after executing a module, useful with scratchpads
 external_editor = "vi" # if set, press ctrl+x ctrl+ee (or v in vi normal mode) to edit prompt in the specified program
 delay_startup = 0 # sometimes the otter runs too fast even before the terminal window is ready; this slows it down by milliseconds; useful when chafa image is skewed
 #callback = "" # if set, will run after module execution; for example, calling swaymsg to adjust window size
+fuzzy_prefix = false # enable fuzzy matching for prefixes; "ill" can match "kill"
+fuzzy_min_length = 2 # minimum input length before fuzzy matching activates
+fuzzy_threshold = 0.7 # similarity threshold (0.0-1.0); higher = stricter matching
 
 
 # ANSI color codes are allowed. However, \x1b should be replaced with \u001B, because the rust toml crate cannot read \x as an escaped character

--- a/config_example/config.toml
+++ b/config_example/config.toml
@@ -36,7 +36,7 @@ delay_startup = 0 # sometimes the otter runs too fast even before the terminal w
 #callback = "" # if set, will run after module execution; for example, calling swaymsg to adjust window size
 fuzzy_prefix = false # enable fuzzy matching for prefixes; "ill" can match "kill"
 fuzzy_min_length = 2 # minimum input length before fuzzy matching activates
-fuzzy_threshold = 0.7 # similarity threshold (0.0-1.0); higher = stricter matching
+fuzzy_threshold = 0.6 # similarity threshold (0.0-1.0); higher = stricter matching
 
 
 # ANSI color codes are allowed. However, \x1b should be replaced with \u001B, because the rust toml crate cannot read \x as an escaped character

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,9 @@ struct General {
     callback: Option<String>,
     external_editor: Option<String>,
     delay_startup: Option<usize>,
+    fuzzy_prefix: Option<bool>,
+    fuzzy_min_length: Option<usize>,
+    fuzzy_threshold: Option<f64>,
 }
 
 #[derive(Deserialize, Default)]
@@ -197,6 +200,9 @@ static OVERLAY_LINES: OnceLock<Mutex<String>> = OnceLock::new();
 static CELL_HEIGHT: OnceLock<usize> = OnceLock::new();
 static SEPARATOR_COUNT: OnceLock<Mutex<usize>> = OnceLock::new();
 static CTRLX_LOCK: OnceLock<Mutex<usize>> = OnceLock::new();
+static FUZZY_PREFIX: OnceLock<Mutex<bool>> = OnceLock::new();
+static FUZZY_MIN_LENGTH: OnceLock<Mutex<usize>> = OnceLock::new();
+static FUZZY_THRESHOLD: OnceLock<Mutex<f64>> = OnceLock::new();
 
 //░█░█░▀█▀░█▀█░▀█▀░░░▄▀░░░░█▀▀░█▀█░█▄█░█▀█░█░░░█▀▀░▀█▀░▀█▀░█▀█░█▀█
 //░█▀█░░█░░█░█░░█░░░░▄█▀░░░█░░░█░█░█░█░█▀▀░█░░░█▀▀░░█░░░█░░█░█░█░█
@@ -1573,6 +1579,32 @@ fn remove_ascii(text: &str) -> String {
     re.replace_all(text, "").to_string()
 }
 
+/// Find the best fuzzy match for input among module prefixes.
+/// Returns Some(module) if similarity >= threshold, None otherwise.
+fn fuzzy_match_prefix<'a>(input: &str, modules: &'a [Module]) -> Option<&'a Module> {
+    let threshold = cached_statics(&FUZZY_THRESHOLD, || 0.7);
+    let min_len = cached_statics(&FUZZY_MIN_LENGTH, || 2);
+
+    if input.len() < min_len {
+        return None;
+    }
+
+    let mut best_match: Option<(&Module, f64)> = None;
+
+    for module in modules {
+        let prefix = remove_ascii(&module.prefix);
+        let similarity = strsim::jaro_winkler(input, &prefix);
+
+        if similarity >= threshold
+            && (best_match.is_none() || similarity > best_match.unwrap().1)
+        {
+            best_match = Some((module, similarity));
+        }
+    }
+
+    best_match.map(|(m, _)| m)
+}
+
 // function to expand env
 fn expand_env_vars(input: &str) -> String {
     let mut result = String::new();
@@ -2059,6 +2091,9 @@ fn main() {
         config().interface.customized_list_order,
         false,
     );
+    init_statics(&FUZZY_PREFIX, config().general.fuzzy_prefix, false);
+    init_statics(&FUZZY_MIN_LENGTH, config().general.fuzzy_min_length, 2);
+    init_statics(&FUZZY_THRESHOLD, config().general.fuzzy_threshold, 0.7);
 
     // rustyline editor setup
     *SELECTION_INDEX
@@ -2300,10 +2335,21 @@ fn main() {
 
         // matching the prompted prefix with module prefixes to decide what to do
         let prompted_prfx = prompt.split_whitespace().next().unwrap_or("");
+
+        // Try exact match first
         let module_prfx = config()
             .modules
             .iter()
             .find(|module| remove_ascii(&module.prefix) == prompted_prfx);
+
+        // If no exact match and fuzzy is enabled, try fuzzy match
+        let module_prfx = module_prfx.or_else(|| {
+            if cached_statics(&FUZZY_PREFIX, || false) {
+                fuzzy_match_prefix(prompted_prfx, &config().modules)
+            } else {
+                None
+            }
+        });
 
         match module_prfx {
             // if user input starts with some module prefixes


### PR DESCRIPTION
## Summary

Adds optional fuzzy matching for module prefix completion, making otter-launcher more forgiving of typos and abbreviations.

## Features

- **Prefix abbreviations**: Type `ki` to match `kill`
- **Suffix matching**: Type `ur` to match `aur`, `ill` to match `kill`
- **Typo tolerance**: Type `searh` to match `search` (Jaro-Winkler algorithm)
- Exact matches always take priority

## Configuration

Add to `[general]` section in your config:

```toml
fuzzy_prefix = false        # enable fuzzy matching
fuzzy_min_length = 2        # minimum chars before fuzzy activates
fuzzy_threshold = 0.6       # similarity threshold (0.0-1.0)