### PR TITLE
nix: add `settingsExtra` option

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -25,13 +25,70 @@ let
             See <https://github.com/kuokuo123/otter-launcher/blob/main/README.md#configuration>.
           '';
         };
+
+        settingsExtra = lib.mkOption {
+          type = lib.types.lines;
+          default = "";
+          defaultText = lib.literalExpression ''""'';
+          description = ''
+            Raw additional configuration lines written to {file}`$XDG_CONFIG_DIR/otter-launcher/config.toml`.
+
+            See <https://github.com/kuokuo123/otter-launcher/blob/main/README.md#configuration>.
+          '';
+          example = # toml
+            ''
+            [interface]
+            # use three quotes to write longer codes
+            header = """
+              \u001B[34;1m$USER@$(printf $HOSTNAME)\u001B[0m     \u001B[31m\u001B[0m $(mpstat | awk 'FNR ==4 {print $4}')
+              """
+            header_cmd = ""
+            header_cmd_trimmed_lines = 0
+            place_holder = "otterly awesome"
+            suggestion_mode = "list"
+            separator = "                  \u001B[90mmodules ────────────────"
+            footer = ""
+            suggestion_lines = 3
+            list_prefix = "  "
+            selection_prefix = "\u001B[31;1m▌ "
+            prefix_padding = 3
+            default_module_message = "  \u001B[33msearch\u001B[0m the internet"
+            empty_module_message = ""
+            customized_list_order = false
+            indicator_with_arg_module = ""
+            indicator_no_arg_module = ""
+            prefix_color = "\u001B[33m"
+            description_color = "\u001B[39m"
+            place_holder_color = "\u001B[30m"
+            hint_color = "\u001B[30m"
+            move_interface_right = 16
+            move_interface_down = 1
+            '';
+        };
       };
 
       config = lib.mkIf cfg.enable {
         home.packages = [ otter-launcher ];
 
-        xdg.configFile."otter-launcher/config.toml" = lib.mkIf (cfg.settings != { }) {
-          source = toml-format.generate "otter-launcher-config" cfg.settings;
+        xdg.configFile."otter-launcher/config.toml" = lib.mkIf (cfg.settings != { } || cfg.settingsExtra != "") {
+          source =
+            let
+              write-settings = lib.optionalString (cfg.settings != { }) ''
+                cat "${toml-format.generate "otter-launcher-settings" cfg.settings}" >> $out
+                echo "" >> $out
+              '';
+
+              write-settings-extra = lib.optionalString (cfg.settingsExtra != "") ''
+                cat "${pkgs.writeText "otter-launcher-settings-extra" cfg.settingsExtra}" >> $out
+                echo "" >> $out
+              '';
+
+              # source = pkgs.runCommand "otter-launcher-config" { } (lib.concatStringsSep "\n" (config-file ++ config-extra));
+              source = pkgs.runCommand "otter-launcher-config" { } ''
+                ${write-settings}
+                ${write-settings-extra}
+              '';
+            in source;
         };
       };
     };

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -25,14 +25,71 @@ let
             See <https://github.com/kuokuo123/otter-launcher/blob/main/README.md#configuration>.
           '';
         };
+
+        settingsExtra = lib.mkOption {
+          type = lib.types.lines;
+          default = "";
+          defaultText = lib.literalExpression ''""'';
+          description = ''
+            Raw additional configuration lines written to {file}`$XDG_CONFIG_DIR/otter-launcher/config.toml`.
+
+            See <https://github.com/kuokuo123/otter-launcher/blob/main/README.md#configuration>.
+          '';
+          example = # toml
+            ''
+            [interface]
+            # use three quotes to write longer codes
+            header = """
+              \u001B[34;1m$USER@$(printf $HOSTNAME)\u001B[0m     \u001B[31m\u001B[0m $(mpstat | awk 'FNR ==4 {print $4}')
+              """
+            header_cmd = ""
+            header_cmd_trimmed_lines = 0
+            place_holder = "otterly awesome"
+            suggestion_mode = "list"
+            separator = "                  \u001B[90mmodules ────────────────"
+            footer = ""
+            suggestion_lines = 3
+            list_prefix = "  "
+            selection_prefix = "\u001B[31;1m▌ "
+            prefix_padding = 3
+            default_module_message = "  \u001B[33msearch\u001B[0m the internet"
+            empty_module_message = ""
+            customized_list_order = false
+            indicator_with_arg_module = ""
+            indicator_no_arg_module = ""
+            prefix_color = "\u001B[33m"
+            description_color = "\u001B[39m"
+            place_holder_color = "\u001B[30m"
+            hint_color = "\u001B[30m"
+            move_interface_right = 16
+            move_interface_down = 1
+            '';
+        };
       };
 
       config = lib.mkIf cfg.enable {
         environment = {
           systemPackages = [ otter-launcher ];
 
-          etc."otter-launcher/config.toml" = lib.mkIf (cfg.settings != { }) {
-            source = toml-format.generate "otter-launcher-config" cfg.settings;
+          etc."otter-launcher/config.toml" = lib.mkIf (cfg.settings != { } || cfg.settingsExtra != "") {
+            source =
+              let
+                write-settings = lib.optionalString (cfg.settings != { }) ''
+                cat "${toml-format.generate "otter-launcher-settings" cfg.settings}" >> $out
+                echo "" >> $out
+                '';
+
+                write-settings-extra = lib.optionalString (cfg.settingsExtra != "") ''
+                cat "${pkgs.writeText "otter-launcher-settings-extra" cfg.settingsExtra}" >> $out
+                echo "" >> $out
+                '';
+
+                # source = pkgs.runCommand "otter-launcher-config" { } (lib.concatStringsSep "\n" (config-file ++ config-extra));
+                source = pkgs.runCommand "otter-launcher-config" { } ''
+                  ${write-settings}
+                  ${write-settings-extra}
+                '';
+              in source;
           };
         };
       };


### PR DESCRIPTION
This PR adds a `settingsExtra` option to both the `home-manager` and `NixOS` modules.
It allows appending raw toml lines to the generated config file, and can be used as workaround for #17.