### PR TITLE
make contrib scripts more portable

### DIFF
--- a/contrib/external-editor-wrapper-niri.sh
+++ b/contrib/external-editor-wrapper-niri.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 niri msg action set-window-height 450 && niri msg action center-window
 nvim -n -c 'redraw!' '+normal G$' "$*"
 niri msg action set-window-height 60 && sleep 0.05 && niri msg action center-window

--- a/contrib/external-editor-wrapper-sway.sh
+++ b/contrib/external-editor-wrapper-sway.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 swaymsg [app_id=otter-launcher] resize set width 510 px height 280 px
 nvim -n -c 'redraw!' '+normal G$' "$*"
 swaymsg [app_id=otter-launcher] resize set width 510 px height 62 px

--- a/contrib/otter-toggle-hyprland
+++ b/contrib/otter-toggle-hyprland
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a bash script that toggles otter-launcher with foot terminal.
 # Modify foot --app-id to others, for example alacritty --class, if you use other emulators.

--- a/contrib/otter-toggle-niri
+++ b/contrib/otter-toggle-niri
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a bash script that toggles otter-launcher with foot terminal.
 # Modify foot --app-id to others, for example alacritty --class, if you use other emulators.

--- a/contrib/otter-toggle-sway
+++ b/contrib/otter-toggle-sway
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a bash script that toggles otter-launcher with foot terminal.
 # Modify foot --app-id to others, for example alacritty --class, if you use other emulators.

--- a/contrib/otter-toggle-sway-scratchpad
+++ b/contrib/otter-toggle-sway-scratchpad
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a bash script that toggles otter-launcher using sway's scratchpad functionality.
 # Modify foot --app-id to others, for example alacritty --class, if you use other emulators.


### PR DESCRIPTION
Having hard coded `#!/bin/bash` makes the scripts less portable. `#!/usr/bin/env bash` uses the first `bash` executable it finds in `PATH`.
As an example, this is needed in Nixos because `/bin/` doesn't hold anything (except `sh`).